### PR TITLE
ci(github-release): use env to escape double quotes

### DIFF
--- a/.github/workflows/github-release.yaml
+++ b/.github/workflows/github-release.yaml
@@ -23,6 +23,7 @@ jobs:
           gh release create "${{ github.ref_name }}" \
             --draft \
             --title "Release ${{ github.ref_name }}" \
-            --notes "${{ steps.generate-changelog.outputs.changelog }}"
+            --notes "$NOTES"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NOTES: ${{ steps.generate-changelog.outputs.changelog }}


### PR DESCRIPTION
https://github.com/autowarefoundation/autoware-github-actions/issues/82