### PR TITLE
fix: exception of no include guard

### DIFF
--- a/pre_commit_hooks/ros_include_guard.py
+++ b/pre_commit_hooks/ros_include_guard.py
@@ -120,9 +120,10 @@ def main(argv=None):
         lines = filepath.read_text().split("\n")
         guard = get_include_guard_info(lines)
         # Error if the include guard is not found.
-        if guard.is_none() and not guard.has_pragma_once:
-            print("No include guard in {}".format(filepath))
-            return_code = 1
+        if guard.is_none():
+            if not guard.has_pragma_once:
+                print("No include guard in {}".format(filepath))
+                return_code = 1
             continue
         # Error and auto fix if the macro name is not correct.
         macro_name = get_include_guard_macro_name(filepath)

--- a/tests/test_ros_include_guard.py
+++ b/tests/test_ros_include_guard.py
@@ -4,19 +4,25 @@ import pytest
 
 from pre_commit_hooks import ros_include_guard
 
-cases = [
+cases_auto_fix = [
     "include/rospkg/foobar.h",
     "include/rospkg/foobar.hpp",
     "include/rospkg/nolint.hpp",
+    "include/rospkg/pragma.hpp",
     "src/foo_bar_baz.hpp",
     "src/foo_bar/baz.hpp",
     "src/foo/bar_baz.hpp",
     "src/foo/bar/baz.hpp",
 ]
 
+cases_no_fix = [
+    ("include/rospkg/pragma.only.hpp", 0),
+    ("include/rospkg/none.hpp", 1),
+]
 
-@pytest.mark.parametrize(("target_file"), cases)
-def test(target_file, datadir):
+
+@pytest.mark.parametrize(("target_file"), cases_auto_fix)
+def test_auto_fix(target_file, datadir):
 
     target_path = datadir.joinpath(target_file)
     right_path = target_path.with_suffix(".right" + target_path.suffix)
@@ -33,3 +39,11 @@ def test(target_file, datadir):
     return_code = ros_include_guard.main([str(target_path)])
     assert return_code == 0
     assert target_path.read_text() == right_path.read_text()
+
+
+@pytest.mark.parametrize(("target_file", "answer_code"), cases_no_fix)
+def test_no_fix(target_file, answer_code, datadir):
+
+    target_path = datadir.joinpath(target_file)
+    return_code = ros_include_guard.main([str(target_path)])
+    assert return_code == answer_code

--- a/tests/test_ros_include_guard/include/rospkg/pragma.only.hpp
+++ b/tests/test_ros_include_guard/include/rospkg/pragma.only.hpp
@@ -1,0 +1,1 @@
+#pragma once

--- a/tests/test_ros_include_guard/include/rospkg/pragma.right.hpp
+++ b/tests/test_ros_include_guard/include/rospkg/pragma.right.hpp
@@ -1,0 +1,5 @@
+#pragma once
+
+#ifndef ROSPKG__PRAGMA_HPP_
+#define ROSPKG__PRAGMA_HPP_
+#endif  // ROSPKG__PRAGMA_HPP_

--- a/tests/test_ros_include_guard/include/rospkg/pragma.wrong.hpp
+++ b/tests/test_ros_include_guard/include/rospkg/pragma.wrong.hpp
@@ -1,0 +1,5 @@
+#pragma once
+
+#ifndef DUMMY
+#define DUMMY
+#endif  // DUMMY


### PR DESCRIPTION
Fix this error.
```
Traceback (most recent call last):
  File "/home/isamu-takagi/.cache/pre-commit/repohvx79fls/py_env-python3/bin/ros-include-guard", line 8, in <module>
    sys.exit(main())
  File "/home/isamu-takagi/.cache/pre-commit/repohvx79fls/py_env-python3/lib/python3.8/site-packages/pre_commit_hooks/ros_include_guard.py", line 129, in main
    guard.prepare(macro_name)
  File "/home/isamu-takagi/.cache/pre-commit/repohvx79fls/py_env-python3/lib/python3.8/site-packages/pre_commit_hooks/ros_include_guard.py", line 77, in prepare
    item.prepare(macro_name)
  File "/home/isamu-takagi/.cache/pre-commit/repohvx79fls/py_env-python3/lib/python3.8/site-packages/pre_commit_hooks/ros_include_guard.py", line 43, in prepare
    if "// NOLINT" in self.text:
TypeError: argument of type 'NoneType' is not iterable
```