### PR TITLE
ci(sync-files): add mistakenly removed settings

### DIFF
--- a/.github/sync-files.yaml
+++ b/.github/sync-files.yaml
@@ -11,3 +11,9 @@
     - source: .prettierignore
     - source: .prettierrc.yaml
     - source: .yamllint.yaml
+
+- repository: autowarefoundation/autoware-github-actions
+  files:
+    - source: .github/workflows/actions-tagger.yaml
+    - source: .github/workflows/github-release.yaml
+    - source: cliff.toml


### PR DESCRIPTION
I mistakenly removed it here. :pleading_face: 
https://github.com/tier4/pre-commit-hooks-ros/pull/33/files