### PR TITLE
chore: update @prettier/plugin-xml to 2.0.1 and prettier to 2.6.2

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -4,7 +4,7 @@
   entry: prettier --write --list-different --ignore-unknown --print-width 200 --xml-self-closing-space false --xml-whitespace-sensitivity ignore
   language: node
   files: .xacro$
-  additional_dependencies: [prettier@2.6.0, "@prettier/plugin-xml@2.0.0"]
+  additional_dependencies: [prettier@2.6.0, "@prettier/plugin-xml@2.0.1"]
 
 - id: prettier-launch-xml
   name: prettier launch.xml
@@ -12,7 +12,7 @@
   entry: prettier --write --list-different --ignore-unknown --print-width 200 --xml-self-closing-space false --xml-whitespace-sensitivity ignore
   language: node
   files: launch.xml$
-  additional_dependencies: [prettier@2.6.0, "@prettier/plugin-xml@2.0.0"]
+  additional_dependencies: [prettier@2.6.0, "@prettier/plugin-xml@2.0.1"]
 
 - id: prettier-package-xml
   name: prettier package.xml
@@ -20,7 +20,7 @@
   entry: prettier --write --list-different --ignore-unknown --print-width 1000 --xml-self-closing-space false --xml-whitespace-sensitivity ignore
   language: node
   files: package.xml$
-  additional_dependencies: [prettier@2.6.0, "@prettier/plugin-xml@2.0.0"]
+  additional_dependencies: [prettier@2.6.0, "@prettier/plugin-xml@2.0.1"]
 
 - id: sort-package-xml
   name: sort package.xml

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -4,7 +4,7 @@
   entry: prettier --write --list-different --ignore-unknown --print-width 200 --xml-self-closing-space false --xml-whitespace-sensitivity ignore
   language: node
   files: .xacro$
-  additional_dependencies: [prettier@2.6.0, "@prettier/plugin-xml@2.0.1"]
+  additional_dependencies: [prettier@2.6.1, "@prettier/plugin-xml@2.0.1"]
 
 - id: prettier-launch-xml
   name: prettier launch.xml
@@ -12,7 +12,7 @@
   entry: prettier --write --list-different --ignore-unknown --print-width 200 --xml-self-closing-space false --xml-whitespace-sensitivity ignore
   language: node
   files: launch.xml$
-  additional_dependencies: [prettier@2.6.0, "@prettier/plugin-xml@2.0.1"]
+  additional_dependencies: [prettier@2.6.1, "@prettier/plugin-xml@2.0.1"]
 
 - id: prettier-package-xml
   name: prettier package.xml
@@ -20,7 +20,7 @@
   entry: prettier --write --list-different --ignore-unknown --print-width 1000 --xml-self-closing-space false --xml-whitespace-sensitivity ignore
   language: node
   files: package.xml$
-  additional_dependencies: [prettier@2.6.0, "@prettier/plugin-xml@2.0.1"]
+  additional_dependencies: [prettier@2.6.1, "@prettier/plugin-xml@2.0.1"]
 
 - id: sort-package-xml
   name: sort package.xml

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -4,7 +4,7 @@
   entry: prettier --write --list-different --ignore-unknown --print-width 200 --xml-self-closing-space false --xml-whitespace-sensitivity ignore
   language: node
   files: .xacro$
-  additional_dependencies: [prettier@2.6.1, "@prettier/plugin-xml@2.0.1"]
+  additional_dependencies: [prettier@2.6.2, "@prettier/plugin-xml@2.0.1"]
 
 - id: prettier-launch-xml
   name: prettier launch.xml
@@ -12,7 +12,7 @@
   entry: prettier --write --list-different --ignore-unknown --print-width 200 --xml-self-closing-space false --xml-whitespace-sensitivity ignore
   language: node
   files: launch.xml$
-  additional_dependencies: [prettier@2.6.1, "@prettier/plugin-xml@2.0.1"]
+  additional_dependencies: [prettier@2.6.2, "@prettier/plugin-xml@2.0.1"]
 
 - id: prettier-package-xml
   name: prettier package.xml
@@ -20,7 +20,7 @@
   entry: prettier --write --list-different --ignore-unknown --print-width 1000 --xml-self-closing-space false --xml-whitespace-sensitivity ignore
   language: node
   files: package.xml$
-  additional_dependencies: [prettier@2.6.1, "@prettier/plugin-xml@2.0.1"]
+  additional_dependencies: [prettier@2.6.2, "@prettier/plugin-xml@2.0.1"]
 
 - id: sort-package-xml
   name: sort package.xml


### PR DESCRIPTION
It's not released yet, but there are some hotfixes.
https://github.com/prettier/plugin-xml/tags

![image](https://user-images.githubusercontent.com/31987104/159611984-3e83fc11-3e3e-406d-ad46-38f64d3cca0a.png)

-> After waiting for a while, it seems there is no problem with this version.