### PR TITLE
chore: update .prettierrc.yaml

### DIFF
--- a/.prettierrc.yaml
+++ b/.prettierrc.yaml
@@ -1,2 +1,20 @@
 printWidth: 100
 tabWidth: 2
+overrides:
+  - files: "package.xml"
+    options:
+      printWidth: 1000
+      xmlSelfClosingSpace: false
+      xmlWhitespaceSensitivity: ignore
+
+  - files: "*.launch.xml"
+    options:
+      printWidth: 200
+      xmlSelfClosingSpace: false
+      xmlWhitespaceSensitivity: ignore
+
+  - files: "*.xacro"
+    options:
+      printWidth: 120
+      xmlSelfClosingSpace: false
+      xmlWhitespaceSensitivity: ignore

--- a/.prettierrc.yaml
+++ b/.prettierrc.yaml
@@ -1,7 +1,7 @@
 printWidth: 100
 tabWidth: 2
 overrides:
-  - files: "package.xml"
+  - files: package.xml
     options:
       printWidth: 1000
       xmlSelfClosingSpace: false

--- a/.prettierrc.yaml
+++ b/.prettierrc.yaml
@@ -15,6 +15,6 @@ overrides:
 
   - files: "*.xacro"
     options:
-      printWidth: 120
+      printWidth: 200
       xmlSelfClosingSpace: false
       xmlWhitespaceSensitivity: ignore


### PR DESCRIPTION
To support auto-format in IDEs.

Regarding the `printWidth` values, I'd like to re-consider and change them later.
But currently, I set the current settings in https://github.com/tier4/pre-commit-hooks-ros/blob/c97f75799b041a0b8e5c641e38610e353bd33373/.pre-commit-hooks.yaml.