### PR TITLE
ci(pre-commit): add clang-format to keep consistent styles

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,43 @@
+# Modified from https://github.com/ament/ament_lint/blob/master/ament_clang_format/ament_clang_format/configuration/.clang-format
+Language: Cpp
+BasedOnStyle: Google
+
+AccessModifierOffset: -2
+AlignAfterOpenBracket: AlwaysBreak
+BraceWrapping:
+  AfterClass: true
+  AfterFunction: true
+  AfterNamespace: true
+  AfterStruct: true
+BreakBeforeBraces: Custom
+ColumnLimit: 100
+ConstructorInitializerIndentWidth: 0
+ContinuationIndentWidth: 2
+DerivePointerAlignment: false
+PointerAlignment: Middle
+ReflowComments: true
+IncludeCategories:
+  # C++ system headers
+  - Regex: <[a-z_]*>
+    Priority: 6
+    CaseSensitive: true
+  # C system headers
+  - Regex: <.*\.h>
+    Priority: 5
+    CaseSensitive: true
+  # Boost headers
+  - Regex: boost/.*
+    Priority: 4
+    CaseSensitive: true
+  # Message headers
+  - Regex: .*_msgs/.*
+    Priority: 3
+    CaseSensitive: true
+  # Other Package headers
+  - Regex: <.*>
+    Priority: 2
+    CaseSensitive: true
+  # Local package headers
+  - Regex: '".*"'
+    Priority: 1
+    CaseSensitive: true

--- a/.github/sync-files.yaml
+++ b/.github/sync-files.yaml
@@ -5,6 +5,7 @@
     - source: .github/workflows/pre-commit-optional.yaml
     - source: .github/workflows/semantic-pull-request.yaml
     - source: .github/workflows/spell-check-differential.yaml
+    - source: .clang-format
     - source: .markdown-link-check.json
     - source: .markdownlint.yaml
     - source: .pre-commit-config-optional.yaml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -71,4 +71,9 @@ repos:
             flake8-quotes,
           ]
 
+  - repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: v13.0.0
+    hooks:
+      - id: clang-format
+
 exclude: .svg

--- a/tests/test_ros_include_guard/include/rospkg/foobar.right.h
+++ b/tests/test_ros_include_guard/include/rospkg/foobar.right.h
@@ -1,3 +1,4 @@
 #ifndef ROSPKG__FOOBAR_H_
 #define ROSPKG__FOOBAR_H_
+
 #endif  // ROSPKG__FOOBAR_H_

--- a/tests/test_ros_include_guard/include/rospkg/foobar.right.hpp
+++ b/tests/test_ros_include_guard/include/rospkg/foobar.right.hpp
@@ -1,3 +1,4 @@
 #ifndef ROSPKG__FOOBAR_HPP_
 #define ROSPKG__FOOBAR_HPP_
+
 #endif  // ROSPKG__FOOBAR_HPP_

--- a/tests/test_ros_include_guard/include/rospkg/foobar.wrong.h
+++ b/tests/test_ros_include_guard/include/rospkg/foobar.wrong.h
@@ -1,3 +1,4 @@
 #ifndef DUMMY
 #define DUMMY
+
 #endif  // DUMMY

--- a/tests/test_ros_include_guard/include/rospkg/foobar.wrong.hpp
+++ b/tests/test_ros_include_guard/include/rospkg/foobar.wrong.hpp
@@ -1,3 +1,4 @@
 #ifndef DUMMY
 #define DUMMY
+
 #endif  // DUMMY

--- a/tests/test_ros_include_guard/include/rospkg/nolint.right.hpp
+++ b/tests/test_ros_include_guard/include/rospkg/nolint.right.hpp
@@ -1,3 +1,3 @@
 #ifndef ROSPKG__NOLINT_HPP_  // NOLINT
 #define ROSPKG__NOLINT_HPP_  // NOLINT
-#endif                       // ROSPKG__NOLINT_HPP_  // NOLINT
+#endif  // ROSPKG__NOLINT_HPP_  // NOLINT

--- a/tests/test_ros_include_guard/include/rospkg/nolint.right.hpp
+++ b/tests/test_ros_include_guard/include/rospkg/nolint.right.hpp
@@ -1,3 +1,3 @@
 #ifndef ROSPKG__NOLINT_HPP_  // NOLINT
 #define ROSPKG__NOLINT_HPP_  // NOLINT
-#endif  // ROSPKG__NOLINT_HPP_  // NOLINT
+#endif                       // ROSPKG__NOLINT_HPP_  // NOLINT

--- a/tests/test_ros_include_guard/include/rospkg/nolint.right.hpp
+++ b/tests/test_ros_include_guard/include/rospkg/nolint.right.hpp
@@ -1,3 +1,4 @@
 #ifndef ROSPKG__NOLINT_HPP_  // NOLINT
 #define ROSPKG__NOLINT_HPP_  // NOLINT
+
 #endif  // ROSPKG__NOLINT_HPP_  // NOLINT

--- a/tests/test_ros_include_guard/include/rospkg/nolint.wrong.hpp
+++ b/tests/test_ros_include_guard/include/rospkg/nolint.wrong.hpp
@@ -1,3 +1,4 @@
 #ifndef DUMMY  // NOLINT
 #define DUMMY  // NOLINT
+
 #endif  // DUMMY  // NOLINT

--- a/tests/test_ros_include_guard/include/rospkg/nolint.wrong.hpp
+++ b/tests/test_ros_include_guard/include/rospkg/nolint.wrong.hpp
@@ -1,3 +1,3 @@
 #ifndef DUMMY  // NOLINT
 #define DUMMY  // NOLINT
-#endif  // DUMMY  // NOLINT
+#endif         // DUMMY  // NOLINT

--- a/tests/test_ros_include_guard/include/rospkg/nolint.wrong.hpp
+++ b/tests/test_ros_include_guard/include/rospkg/nolint.wrong.hpp
@@ -1,3 +1,3 @@
 #ifndef DUMMY  // NOLINT
 #define DUMMY  // NOLINT
-#endif         // DUMMY  // NOLINT
+#endif  // DUMMY  // NOLINT

--- a/tests/test_ros_include_guard/include/rospkg/pragma.right.hpp
+++ b/tests/test_ros_include_guard/include/rospkg/pragma.right.hpp
@@ -2,4 +2,5 @@
 
 #ifndef ROSPKG__PRAGMA_HPP_
 #define ROSPKG__PRAGMA_HPP_
+
 #endif  // ROSPKG__PRAGMA_HPP_

--- a/tests/test_ros_include_guard/include/rospkg/pragma.wrong.hpp
+++ b/tests/test_ros_include_guard/include/rospkg/pragma.wrong.hpp
@@ -2,4 +2,5 @@
 
 #ifndef DUMMY
 #define DUMMY
+
 #endif  // DUMMY


### PR DESCRIPTION
This can guarantee that `ros_include_guard` doesn't conflict with `clang-format`.