### PR TITLE
chore(test): refactor test code

### DIFF
--- a/tests/test_sort_package_xml.py
+++ b/tests/test_sort_package_xml.py
@@ -1,5 +1,4 @@
 from pathlib import Path
-import shutil
 
 import pytest
 
@@ -17,17 +16,13 @@ def test(case: str, datadir: Path, tmp_path: Path):
     input_file = datadir / f"{case}.input.xml"
     answer_file = datadir / f"{case}.answer.xml"
 
-    # Create a temporary file to prevent overwriting original files
-    tmp_file = tmp_path / f"{case}.input.xml"
-    shutil.copy(input_file, tmp_file)
-
     # Format
-    return_code = sort_package_xml.main([str(tmp_file)])
-    print(tmp_file.read_text())
+    return_code = sort_package_xml.main([str(input_file)])
+    print(input_file.read_text())
     assert return_code == 1
-    assert tmp_file.read_text() == answer_file.read_text()
+    assert input_file.read_text() == answer_file.read_text()
 
     # Re-format
-    return_code = sort_package_xml.main([str(tmp_file)])
+    return_code = sort_package_xml.main([str(input_file)])
     assert return_code == 0
-    assert tmp_file.read_text() == answer_file.read_text()
+    assert input_file.read_text() == answer_file.read_text()


### PR DESCRIPTION
Related https://github.com/tier4/autoware-spell-check-dict/pull/256

There is no need to copy the original file, so I changed the test code.

> pytest-datadir will copy the original file to a temporary folder, so changing the file contents won't change the original data file.

https://pypi.org/project/pytest-datadir/

Signed-off-by: Keisuke Shima <19993104+KeisukeShima@users.noreply.github.com>