### PR TITLE
ci(pre-commit): update black

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,7 +50,7 @@ repos:
       - id: isort
 
   - repo: https://github.com/psf/black
-    rev: 22.1.0
+    rev: 22.3.0
     hooks:
       - id: black
         args: [--line-length=100]


### PR DESCRIPTION
Fix error https://github.com/tier4/pre-commit-hooks-ros/runs/5729446750?check_suite_focus=true

Related: https://github.com/psf/black/issues/2964