### PR TITLE
feat: add flake8-ros hook

### DIFF
--- a/.github/workflows/test-pre-commit-hooks.yaml
+++ b/.github/workflows/test-pre-commit-hooks.yaml
@@ -14,3 +14,14 @@ jobs:
         uses: autowarefoundation/autoware-github-actions/pre-commit@v1
         with:
           pre-commit-config: tests/pre-commit-hooks/test-pre-commit-hooks.yaml
+
+      - name: Try pre-commit
+        run: |
+          pre-commit try-repo https://github.com/tier4/pre-commit-hooks-ros flake8-ros -a --ref ${{ github.ref }}
+
+      - name: Try pre-commit with fault injected
+        run: |
+          echo "import os" >> pre_commit_hooks/sort_package_xml.py
+          if pre-commit try-repo https://github.com/tier4/pre-commit-hooks-ros flake8-ros -a --ref ${{ github.ref }}; then
+              exit 1
+          fi

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,3 +1,23 @@
+- id: flake8-ros
+  name: flake8 ros
+  description: Apply flake8 with the ROS 2 settings.
+  entry: flake8
+  language: python
+  types: [python]
+  # require_serial: true
+  additional_dependencies:
+    [
+      flake8==4.0.1,
+      flake8-blind-except,
+      flake8-builtins,
+      flake8-class-newline,
+      flake8-comprehensions,
+      flake8-deprecated,
+      flake8-docstrings,
+      flake8-import-order,
+      flake8-quotes,
+    ]
+
 - id: prettier-xacro
   name: prettier xacro
   description: Apply Prettier with plugin-xml to xacro.

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,3 +1,4 @@
+# Modified from https://github.com/PyCQA/flake8/blob/463d9b1ce9ee44665f2c6825edd7010ef5dff760/.pre-commit-hooks.yaml
 - id: flake8-ros
   name: flake8 ros
   description: Apply flake8 with the ROS 2 settings.

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -4,7 +4,7 @@
   entry: flake8
   language: python
   types: [python]
-  # require_serial: true
+  require_serial: true
   additional_dependencies:
     [
       flake8==4.0.1,

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ repos:
   - repo: https://github.com/tier4/pre-commit-hooks-ros
     rev: v0.6.0
     hooks:
+      - id: flake8-ros
       - id: prettier-xacro
       - id: prettier-launch-xml
       - id: prettier-package-xml
@@ -19,6 +20,10 @@ repos:
 ```
 
 ## Hooks available
+
+### flake8-ros
+
+Apply [flake8] with the [ROS 2 settings](https://docs.ros.org/en/rolling/Installation/Ubuntu-Development-Setup.html#install-development-tools-and-ros-tools).
 
 ### prettier-xacro
 
@@ -47,6 +52,7 @@ If you want to exclude a tag from sorting, add `<! -- no format -->` at the begi
 
 <!-- Links -->
 
+[flake8]: https://github.com/PyCQA/flake8
 [launch.xml]: https://design.ros2.org/articles/roslaunch_xml.html
 [package.xml]: https://www.ros.org/reps/rep-0149.html
 [plugin-xml]: https://github.com/prettier/plugin-xml/

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Write your `.pre-commit-config.yaml` as below.
 ```yaml
 repos:
   - repo: https://github.com/tier4/pre-commit-hooks-ros
-    rev: v0.6.0
+    rev: v0.7.0
     hooks:
       - id: flake8-ros
       - id: prettier-xacro


### PR DESCRIPTION
A hook to apply flake8 with the ROS 2 settings.
https://docs.ros.org/en/rolling/Installation/Ubuntu-Development-Setup.html#install-development-tools-and-ros-tools

Internal link about whether to add this hook to this repository: https://github.com/tier4/aip_launcher.iv/pull/38#discussion_r740972434