### PR TITLE
chore: update flake8 version from 6.0.0 to 6.1.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,7 +56,7 @@ repos:
         args: [--line-length=100]
 
   - repo: https://github.com/PyCQA/flake8
-    rev: 6.0.0
+    rev: 6.1.0
     hooks:
       - id: flake8
         additional_dependencies:

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -8,7 +8,7 @@
   require_serial: true
   additional_dependencies:
     [
-      flake8==6.0.0,
+      flake8==6.1.0,
       flake8-blind-except==0.2.1,
       flake8-builtins==2.1.0,
       flake8-class-newline==1.6.0,


### PR DESCRIPTION
This change is already done in https://github.com/tier4/pre-commit-hooks-ros/releases/tag/v0.9.0 but it is not in the main branch for some reason.

This is causing problems here:
- This PR: https://github.com/autowarefoundation/autoware_launch/pull/1056
- https://results.pre-commit.ci/run/github/429697802/1720175089.xp-x1irGTmyerOf0_CjTuw
```
.github/update-sync-param-files.py:14:19: E231 missing whitespace after ':'
REPO_URL = f"https://github.com/{REPO_NAME}.git"
                  ^
1     E231 missing whitespace after ':'
```

And solution is to switch to `flake8 6.1` as stated in this post: https://stackoverflow.com/questions/77527580/pre-commit-throwing-errors-on-missing-whitespace-after

And let's do another release (`v0.10.0`) with this commit.

cc. @SakodaShintaro 