### PR TITLE
fix: add setuptools to flake8-ros additional dependencies

### DIFF
--- a/.github/workflows/test-pre-commit-hooks.yaml
+++ b/.github/workflows/test-pre-commit-hooks.yaml
@@ -10,6 +10,11 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v3
 
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+
       - name: Run pre-commit
         uses: autowarefoundation/autoware-github-actions/pre-commit@v1
         with:

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -8,6 +8,7 @@
   require_serial: true
   additional_dependencies:
     [
+      setuptools,
       flake8==6.1.0,
       flake8-blind-except==0.2.1,
       flake8-builtins==2.1.0,

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -8,7 +8,7 @@
   require_serial: true
   additional_dependencies:
     [
-      setuptools,
+      setuptools==65.0.0,
       flake8==6.1.0,
       flake8-blind-except==0.2.1,
       flake8-builtins==2.1.0,


### PR DESCRIPTION
Curiously, when running pre-commit-lite, flake8-ros in AWF side works well but always fail in tier4 fork. 

https://github.com/tier4/autoware_universe/actions/runs/21932363694/job/63338966797?pr=2674

```
flake8 ros...............................................................Failed
- hook id: flake8-ros
- exit code: 1

Traceback (most recent call last):
  File "/home/runner/.cache/pre-commit/repo7hwzyfig/py_env-python3.14/lib/python3.14/site-packages/flake8/plugins/finder.py", line 291, in _load_plugin
    obj = plugin.entry_point.load()
  File "/opt/hostedtoolcache/Python/3.14.2/x64/lib/python3.14/importlib/metadata/__init__.py", line 179, in load
    module = import_module(match.group('module'))
  File "/opt/hostedtoolcache/Python/3.14.2/x64/lib/python3.14/importlib/__init__.py", line 88, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap>", line 1398, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1371, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1342, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 938, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 759, in exec_module
  File "<frozen importlib._bootstrap>", line 491, in _call_with_frames_removed
  File "/home/runner/.cache/pre-commit/repo7hwzyfig/py_env-python3.14/lib/python3.14/site-packages/flake8_import_order/flake8_linter.py", line 6, in <module>
    from flake8_import_order.checker import (
        DEFAULT_IMPORT_ORDER_STYLE, ImportOrderChecker,
    )
  File "/home/runner/.cache/pre-commit/repo7hwzyfig/py_env-python3.14/lib/python3.14/site-packages/flake8_import_order/checker.py", line 8, in <module>
    from flake8_import_order.styles import lookup_entry_point
  File "/home/runner/.cache/pre-commit/repo7hwzyfig/py_env-python3.14/lib/python3.14/site-packages/flake8_import_order/styles.py", line 3, in <module>
    from pkg_resources import iter_entry_points
ModuleNotFoundError: No module named 'pkg_resources'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/runner/.cache/pre-commit/repo7hwzyfig/py_env-python3.14/bin/flake8", line 7, in <module>
    sys.exit(main())
             ~~~~^^
  File "/home/runner/.cache/pre-commit/repo7hwzyfig/py_env-python3.14/lib/python3.14/site-packages/flake8/main/cli.py", line 23, in main
    app.run(argv)
    ~~~~~~~^^^^^^
  File "/home/runner/.cache/pre-commit/repo7hwzyfig/py_env-python3.14/lib/python3.14/site-packages/flake8/main/application.py", line 198, in run
    self._run(argv)
    ~~~~~~~~~^^^^^^
  File "/home/runner/.cache/pre-commit/repo7hwzyfig/py_env-python3.14/lib/python3.14/site-packages/flake8/main/application.py", line 186, in _run
    self.initialize(argv)
    ~~~~~~~~~~~~~~~^^^^^^
  File "/home/runner/.cache/pre-commit/repo7hwzyfig/py_env-python3.14/lib/python3.14/site-packages/flake8/main/application.py", line 165, in initialize
    self.plugins, self.options = parse_args(argv)
                                 ~~~~~~~~~~^^^^^^
  File "/home/runner/.cache/pre-commit/repo7hwzyfig/py_env-python3.14/lib/python3.14/site-packages/flake8/options/parse_args.py", line 42, in parse_args
    plugins = finder.load_plugins(raw_plugins, plugin_opts)
  File "/home/runner/.cache/pre-commit/repo7hwzyfig/py_env-python3.14/lib/python3.14/site-packages/flake8/plugins/finder.py", line 365, in load_plugins
    return _classify_plugins(_import_plugins(plugins, opts), opts)
                             ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^
  File "/home/runner/.cache/pre-commit/repo7hwzyfig/py_env-python3.14/lib/python3.14/site-packages/flake8/plugins/finder.py", line 307, in _import_plugins
    return [_load_plugin(p) for p in plugins]
            ~~~~~~~~~~~~^^^
  File "/home/runner/.cache/pre-commit/repo7hwzyfig/py_env-python3.14/lib/python3.14/site-packages/flake8/plugins/finder.py", line 293, in _load_plugin
    raise FailedToLoadPlugin(plugin.package, e)
flake8.exceptions.FailedToLoadPlugin: Flake8 failed to load plugin "flake8-import-order" due to No module named 'pkg_resources'.

prettier xacro.......................................(no files to check)Skipped
prettier launch.xml......................................................Passed
prettier package.xml.....................................................Passed
fix include guard........................................................Passed
sort package.xml.........................................................Passed
shellcheck...............................................................Passed
shfmt....................................................................Passed
isort....................................................................Passed
black....................................................................Passed
clang-format.............................................................Passed
cpplint..................................................................Passed
Validate JSON Schema files...............................................Passed
prettier svg.............................................................Passed
Hadolint.............................................(no files to check)Skipped
```

Adding additional dependencies worked (although the pre-commit itself failed)
```yaml
  - repo: https://github.com/tier4/pre-commit-hooks-ros
    rev: v0.10.0
    hooks:
      - id: flake8-ros
        additional_dependencies: [setuptools, flake8]
      - (...)
```

https://github.com/tier4/autoware_universe/actions/runs/21936694617/job/63352321525?pr=2677

Adding `additional_dependencies: [setuptools]` alone fails because it couldn't find flake8. It seems like `additional_dependencies` are overwritten instead of being appended.

I pinned the version into `setuptools==65.0.0` only because Copilot suggested to do so. If there are any more good reason to use newer one (the latest is 82.0.0 on Feb 2026) then we can bump it.

After merging PR, I would like to release version v0.10.1 and update pre-commit-config.
