### PR TITLE
chore: bump flake-import-order to 0.19.2

### DIFF
--- a/.github/workflows/test-pre-commit-hooks.yaml
+++ b/.github/workflows/test-pre-commit-hooks.yaml
@@ -10,11 +10,6 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v3
 
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: "3.10"
-
       - name: Run pre-commit
         uses: autowarefoundation/autoware-github-actions/pre-commit@v1
         with:

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -16,7 +16,7 @@
       flake8-comprehensions==3.12.0,
       flake8-deprecated==2.0.1,
       flake8-docstrings==1.7.0,
-      flake8-import-order==0.18.2,
+      flake8-import-order==0.19.2,
       flake8-quotes==3.3.2,
     ]
 


### PR DESCRIPTION
This enables flake8-ros running on python3.12.