### PR TITLE
fix(ros-include-guard): don't rewrite non-guard #ifndef blocks in #pragma once headers

### DIFF
--- a/pre_commit_hooks/ros_include_guard.py
+++ b/pre_commit_hooks/ros_include_guard.py
@@ -76,6 +76,12 @@ class IncludeGuard:
         for item in self.items():
             item.prepare(macro_name)
 
+    def wraps_whole_file(self, lines):
+        # A real include guard's #endif closes the file, so only blank lines may
+        # follow it. If anything else follows, the detected #ifndef/#define/#endif
+        # is not an include guard but some other conditional block.
+        return all(not line.strip() for line in lines[self.endif.line + 1 :])
+
 
 def get_include_guard_info(lines):
     guard = IncludeGuard()
@@ -121,6 +127,12 @@ def main(argv=None):
             if not guard.has_pragma_once:
                 print("No include guard in {}".format(filepath))
                 return_code = 1
+            continue
+        # A file that uses `#pragma once` is already guarded. Its #ifndef/#define
+        # block is only the include guard if it wraps the whole file; otherwise it
+        # is something else (e.g. a feature-test macro like `#ifndef _GNU_SOURCE`)
+        # and must be left untouched.
+        if guard.has_pragma_once and not guard.wraps_whole_file(lines):
             continue
         # Error and auto fix if the macro name is not correct.
         macro_name = get_include_guard_macro_name(filepath)

--- a/pre_commit_hooks/ros_include_guard.py
+++ b/pre_commit_hooks/ros_include_guard.py
@@ -76,24 +76,33 @@ class IncludeGuard:
         for item in self.items():
             item.prepare(macro_name)
 
-    def wraps_whole_file(self, lines):
-        # A real include guard's #endif closes the file, so only blank lines may
-        # follow it. If anything else follows, the detected #ifndef/#define/#endif
-        # is not an include guard but some other conditional block.
-        return all(not line.strip() for line in lines[self.endif.line + 1 :])
-
 
 def get_include_guard_info(lines):
     guard = IncludeGuard()
+    content_lines = [(line, text) for line, text in enumerate(lines) if text.strip()))
+    
+    if not content_lines:
+        return guard
+
+    guard.has_pragma_once = any(
+            text.startswith("#pragma once") 
+            for _, text 
+            in enumerate(content_lines)
+    )
+
+    # An include guard is characterized (among other criteria) by an #endif
+    # as the last content line. #endifs that are not on the last content line
+    # could be parts of feature test macros or conditionally compiled features.
+    line, text = content_lines[-1]
+    if not text.startswith("#endif"):
+        return guard
+    guard.endif.update(line, text)
+
     for line, text in enumerate(lines):
-        if text.startswith("#pragma once"):
-            guard.has_pragma_once = True
         if text.startswith("#ifndef") and guard.ifndef.is_none():
             guard.ifndef.update(line, text)
         if text.startswith("#define") and guard.define.is_none():
             guard.define.update(line, text)
-        if text.startswith("#endif"):
-            guard.endif.update(line, text)
     return guard
 
 
@@ -127,12 +136,6 @@ def main(argv=None):
             if not guard.has_pragma_once:
                 print("No include guard in {}".format(filepath))
                 return_code = 1
-            continue
-        # A file that uses `#pragma once` is already guarded. Its #ifndef/#define
-        # block is only the include guard if it wraps the whole file; otherwise it
-        # is something else (e.g. a feature-test macro like `#ifndef _GNU_SOURCE`)
-        # and must be left untouched.
-        if guard.has_pragma_once and not guard.wraps_whole_file(lines):
             continue
         # Error and auto fix if the macro name is not correct.
         macro_name = get_include_guard_macro_name(filepath)

--- a/pre_commit_hooks/ros_include_guard.py
+++ b/pre_commit_hooks/ros_include_guard.py
@@ -79,26 +79,22 @@ class IncludeGuard:
 
 def get_include_guard_info(lines):
     guard = IncludeGuard()
-    content_lines = [(line, text) for line, text in enumerate(lines) if text.strip()))
-    
+    content_lines = [(line, text) for line, text in enumerate(lines) if text.strip()]
+
     if not content_lines:
         return guard
 
-    guard.has_pragma_once = any(
-            text.startswith("#pragma once") 
-            for _, text 
-            in enumerate(content_lines)
-    )
+    guard.has_pragma_once = any(text.startswith("#pragma once") for _, text in content_lines)
 
     # An include guard is characterized (among other criteria) by an #endif
-    # as the last content line. #endifs that are not on the last content line
+    # as the last content line. #endif's that are not on the last content line
     # could be parts of feature test macros or conditionally compiled features.
     line, text = content_lines[-1]
     if not text.startswith("#endif"):
         return guard
     guard.endif.update(line, text)
 
-    for line, text in enumerate(lines):
+    for line, text in content_lines:
         if text.startswith("#ifndef") and guard.ifndef.is_none():
             guard.ifndef.update(line, text)
         if text.startswith("#define") and guard.define.is_none():

--- a/tests/test_ros_include_guard.py
+++ b/tests/test_ros_include_guard.py
@@ -17,6 +17,7 @@ cases_auto_fix = [
 
 cases_no_fix = [
     ("include/rospkg/pragma.only.hpp", 0),
+    ("include/rospkg/feature_macro.hpp", 0),
     ("include/rospkg/none.hpp", 1),
 ]
 
@@ -43,5 +44,7 @@ def test_auto_fix(target_file, datadir):
 @pytest.mark.parametrize(("target_file", "answer_code"), cases_no_fix)
 def test_no_fix(target_file, answer_code, datadir):
     target_path = datadir.joinpath(target_file)
+    original_text = target_path.read_text()
     return_code = ros_include_guard.main([str(target_path)])
     assert return_code == answer_code
+    assert target_path.read_text() == original_text

--- a/tests/test_ros_include_guard/include/rospkg/feature_macro.hpp
+++ b/tests/test_ros_include_guard/include/rospkg/feature_macro.hpp
@@ -1,0 +1,8 @@
+#pragma once
+
+// A feature-test macro is not an include guard and must be left untouched.
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
+#include <cstring>


### PR DESCRIPTION
## Problem

`ros-include-guard` identifies the include guard as *the first `#ifndef`, the first `#define`, and the last `#endif`*, then rewrites those macro names to the canonical path-based name. That is correct for a header whose include guard wraps the whole file, but a `#pragma once` header can contain unrelated `#ifndef/#define/#endif` blocks that are **not** guards — most commonly a feature-test macro:

```cpp
#pragma once

#ifndef _GNU_SOURCE
#define _GNU_SOURCE
#endif

#include <cstring>
```

The hook treats `_GNU_SOURCE` as the guard and rewrites it:

```cpp
#pragma once

#ifndef RCLCPP__..._HPP_
#define RCLCPP__..._HPP_
#endif  // RCLCPP__..._HPP_

#include <cstring>
```

`#define _GNU_SOURCE` is silently dropped, producing broken code. Because the hook is an autofix, `pre-commit.ci` commits this automatically. We hit this on several real headers (`_GNU_SOURCE` feature macros, and `#ifndef _SRC_CALIBRATION_DIR_PATH / #define ... ""` fallback defaults) while adopting the hook in [tier4/nebula](https://github.com/tier4/nebula).

The existing `#pragma once` handling only kicks in when the file has *no* complete `#ifndef/#define/#endif` triple at all (`pragma.only.hpp`), so a `#pragma once` file that also contains any such block still gets rewritten.

## Fix

A real include guard's `#endif` closes the file, so only blank lines may follow it. When a file already relies on `#pragma once` and its detected `#ifndef/#define/#endif` does **not** wrap the whole file, it isn't the include guard — so leave it untouched.

Headers that use `#pragma once` together with a redundant *full-file* `#ifndef` guard (the existing `pragma.wrong.hpp` → `pragma.right.hpp` case) are unaffected and still get normalized.

## Tests

- New fixture `feature_macro.hpp` (`#pragma once` + a `#ifndef _GNU_SOURCE` block followed by code) added to `cases_no_fix`; verified the hook returns 0 and leaves it byte-for-byte unchanged.
- `test_no_fix` now also asserts the file content is unchanged, so any future regression that rewrites a no-fix file is caught.
- Full suite passes (`13 passed`). All pre-existing behavior (`foobar`, `nolint`, `pragma.right/wrong`, `src/**`, `none.hpp`) is preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)